### PR TITLE
Reference materials for loading data

### DIFF
--- a/docs/dev/front/loading_data_for_emulator.md
+++ b/docs/dev/front/loading_data_for_emulator.md
@@ -35,7 +35,7 @@ Sometimes, it is useful to load data into a deployment config for testing, demo,
 1. Fork `nrel-openpath-deploy-configs`
 2. Modify the config you want to work on, making sure that there is no `server` defined (if no server is defined, the app will connect to the local server, as desired).
 3. Update the downloadURL in `dynamicConfig` for the version of `e-mission-phone` you are running to `https://raw.githubusercontent.com/[MY-REPO]/nrel-openpath-deploy-configs/[MY-BRANCH]/configs/${label}.nrel-op.json`
-4. Now you can use a development config with the local server
+4. Now you can use a deployment config with the local server
 
 ## Notes on making up a valid opcode
 - opcodes must begin with `nrelop`

--- a/docs/dev/front/loading_data_for_emulator.md
+++ b/docs/dev/front/loading_data_for_emulator.md
@@ -1,0 +1,46 @@
+# How to Load Data into Local Server for Use with devapp
+
+In order to fully test the functionality of the devapp, you will usually need to create an opcode with data. You **can** login to the devapp with a "real" opcode (ie the one you are logged into on a physical phone), which is useful for debugging. For more general development purposes, however, it is often more useful to work with sample data, loaded into an opcode of your choice. There are a few useful routes provided by the server for accomplishing this.
+
+## Load Test Data from Server
+
+You can find sample data in `e-mission-server/emission/tests/data/real_examples`. 
+Then, you can load the data into an opcode with the following two scripts. Make sure you have activated the emission environment first.
+
+```./e-mission-py.bash bin/debug/load_timeline_for_day_and_user.py emission/tests/data/real_examples/[file of your choice] nrelop_[complete valid opcode]```
+
+```./e-mission-py.bash bin/debug/intake_single_user.py -e nrelop_[same valid opcode]```
+
+After these two commands run sucessfully, you should be able to run the server and login with the opcode you created in the devapp.
+
+## Load Data from Local File
+
+Sometimes, you will have specific data that you want to load into the emulator. Once you have the two g-zipped files in a local directory, you can load the data into an opcode:
+
+`./e-mission-py bin/debug/load_multi_timeline_for_range.py [path/to/files/with/prefix` -- this path might look something like `/Users/name/Downloads/my_test_data/test_data` where `my_test_data` is a folder containing the two g-zipped files that each start with `test_data`
+
+The data will automatically create a "user email" for this opcode, by default it will be "user-0". This can be updated with: `edb.get_uuid_db().update_one({"user_email": "user-0"}, {"$set": {"user_email": "nrelop_usaid-laos-ev_default_test-1"}})`
+
+Then, process the data by running the pipeline.
+
+`./e-mission-py.bash bin/debug/intake_single_user.py -e [user-0 or updated]`
+
+If you updated to a valid opcode, you can now start the server and log into the devapp with that opcode
+
+## Not on Working with Deployment Configs
+
+There are development configs designed to be used with the local server. They include `dev-emulator-program`, `dev-emulator-study`, and `dev-emulator-timeuse`. 
+
+Sometimes, it is useful to load data into a deployment config for testing, demo, or debugging purposes. If you want to use the local server and a deployment config, you need to take a few extra steps. 
+1. Fork `nrel-openpath-deploy-configs`
+2. Modify the config you want to work on, making sure that there is no `server` defined (if no server is defined, the app will connect to the local server, as desired).
+3. Update the downloadURL in `dynamicConfig` for the version of `e-mission-phone` you are running to `https://raw.githubusercontent.com/[MY-REPO]/nrel-openpath-deploy-configs/[MY-BRANCH]/configs/${label}.nrel-op.json`
+4. Now you can use a development config with the local server
+
+## Notes on making up a valid opcode
+- opcodes must begin with `nrelop`
+- opcodes must contain the name of a config (ie `dev-emulator-study` or `nrel-commute`)
+- some configs require a subgroup (ie `default` or `test`)
+- the endings to opcodes can be anything, it is most useful to choose something memorable (ie `myTestData` or `test2`)
+
+All together the structure should be `nrelop_configName_subgroup_ending`

--- a/docs/dev/front/loading_data_for_emulator.md
+++ b/docs/dev/front/loading_data_for_emulator.md
@@ -17,7 +17,7 @@ After these two commands run sucessfully, you should be able to run the server a
 
 Sometimes, you will have specific data that you want to load into the emulator. Once you have the two g-zipped files in a local directory, you can load the data into an opcode:
 
-`./e-mission-py bin/debug/load_multi_timeline_for_range.py [path/to/files/with/prefix` -- this path might look something like `/Users/name/Downloads/my_test_data/test_data` where `my_test_data` is a folder containing the two g-zipped files that each start with `test_data`
+`./e-mission-py bin/debug/load_multi_timeline_for_range.py [path/to/files/with/prefix]` -- this path might look something like `/Users/name/Downloads/my_test_data/test_data` where `my_test_data` is a folder containing the two g-zipped files that each start with `test_data`
 
 The data will automatically create a "user email" for this opcode, by default it will be "user-0". This can be updated with: `edb.get_uuid_db().update_one({"user_email": "user-0"}, {"$set": {"user_email": "nrelop_usaid-laos-ev_default_test-1"}})`
 
@@ -27,7 +27,7 @@ Then, process the data by running the pipeline.
 
 If you updated to a valid opcode, you can now start the server and log into the devapp with that opcode
 
-## Not on Working with Deployment Configs
+## Note on Working with Deployment Configs
 
 There are development configs designed to be used with the local server. They include `dev-emulator-program`, `dev-emulator-study`, and `dev-emulator-timeuse`. 
 

--- a/docs/dev/front/loading_data_for_emulator.md
+++ b/docs/dev/front/loading_data_for_emulator.md
@@ -19,7 +19,7 @@ Sometimes, you will have specific data that you want to load into the emulator. 
 
 `./e-mission-py bin/debug/load_multi_timeline_for_range.py [path/to/files/with/prefix]` -- this path might look something like `/Users/name/Downloads/my_test_data/test_data` where `my_test_data` is a folder containing the two g-zipped files that each start with `test_data`
 
-The data will automatically create a "user email" for this opcode, by default it will be "user-0". This can be updated with: `edb.get_uuid_db().update_one({"user_email": "user-0"}, {"$set": {"user_email": "nrelop_usaid-laos-ev_default_test-1"}})`
+The script will automatically create a "user email" for this opcode, by default it will be "user-0". This can be updated with: `edb.get_uuid_db().update_one({"user_email": "user-0"}, {"$set": {"user_email": "nrelop_[valid opcode]"}})`
 
 Then, process the data by running the pipeline.
 


### PR DESCRIPTION
After recent struggles remembering how to carry out the different variations of loading data into an opcode on the local server to then work with it in the emulator, I'm documenting them here for future reference. The file that I included references how to:

- load data from the sample files in the server
- load data from gz files
- work with a deployment config on the local server
- make up a valid opcode

Once this is finalized, should I link this anywhere? I could see it being useful linked to server, phone, and/or deploy-configs