### PR TITLE
Update Plugin build instructions

### DIFF
--- a/docs/dev/front/how_to_test_changes _to_a_plugin.md
+++ b/docs/dev/front/how_to_test_changes _to_a_plugin.md
@@ -66,12 +66,14 @@ While the above approach helps test small changes, It is very time-consuming whe
 
 ```bash
 # Copy files into platforms for building
-$ cordova prepare
+$ npx cordova prepare
 
 # Build the platform specific code
-cordova build <platform>
+npx cordova build <platform>
 ```
 > Replace the `<platform>` with either `ios` or `android`.
+
+> Make sure you also ["bundle the js webpack"](https://github.com/e-mission/e-mission-phone?tab=readme-ov-file#building-the-app) or there will be no app UI
 
 ## 2. Then, open the project in your IDE.
 


### PR DESCRIPTION
Updates to instructions including npx and the fact that you must build the javascript code in order for the UI to work.

The fact that I had not built the webpack was the issue I was having in #1114 when I could not get the app to work. 